### PR TITLE
Update transform-afdMasterAgreement-to-policySuperStructure-jLio-scri…

### DIFF
--- a/scripts/transform-afdMasterAgreement-to-policySuperStructure-jLio-script.json
+++ b/scripts/transform-afdMasterAgreement-to-policySuperStructure-jLio-script.json
@@ -2,7 +2,7 @@
   {
     "path": "$.source.masterAgreement[*].policy[*].masterAgreementRef",
     "value": [],
-    "command": "set"
+    "command": "add"
   },
   {
     "fromPath": "$.source.masterAgreement[*].refKey",


### PR DESCRIPTION
…pt.json

The script created the masterAgreementRef property as a string, but it should have created an array of strings.